### PR TITLE
Version 1.1.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
 
     <groupId>moe.tristan</groupId>
     <artifactId>easyfxml</artifactId>
-    <version>1.1.2</version>
+    <version>1.1.3</version>
     <packaging>jar</packaging>
 
     <properties>

--- a/src/main/java/moe/tristan/easyfxml/model/components/listview/ComponentCellFxmlController.java
+++ b/src/main/java/moe/tristan/easyfxml/model/components/listview/ComponentCellFxmlController.java
@@ -7,6 +7,6 @@ import javafx.beans.binding.BooleanExpression;
 public interface ComponentCellFxmlController<T> extends FxmlController {
 
     void updateWithValue(final T newValue);
-    void selectedProperty(final BooleanExpression selected);
+    default void selectedProperty(final BooleanExpression selected) {}
 
 }


### PR DESCRIPTION
Make `ComponentCellFxmlController#selectedProperty(BooleanExpression)` default-implemented with no instruction so components that do not care can just ignore it.