### PR TITLE
Release 1.1.8

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,12 +17,12 @@ Trivia :
 
 [![Quality gate status](https://sonar.tristan.moe/api/project_badges/quality_gate?project=moe.tristan%3Aeasyfxml)](https://sonar.tristan.moe/dashboard?id=moe.tristan%3Aeasyfxml)
 
-Maven dependency : [![Maven Central](https://maven-badges.herokuapp.com/maven-central/moe.tristan/easyfxml/badge.svg)](http://search.maven.org/#artifactdetails%7Cmoe.tristan%7Ceasyfxml%7C1.1.7%7Cjar)
+Maven dependency : [![Maven Central](https://img.shields.io/badge/maven--central-1.1.8-blue.svg)](https://search.maven.org/artifact/moe.tristan/easyfxml/1.1.8/jar)
 ```xml
 <dependency>
     <groupId>moe.tristan</groupId>
     <artifactId>easyfxml</artifactId>
-    <version>1.1.7</version>
+    <version>1.1.8</version>
 </dependency>
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -85,11 +85,6 @@
                         </goals>
                     </execution>
                 </executions>
-                <configuration>
-                    <additionalOptions>
-                        <additionalOption>-html5</additionalOption>
-                    </additionalOptions>
-                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.jacoco</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
 
     <groupId>moe.tristan</groupId>
     <artifactId>easyfxml</artifactId>
-    <version>1.1.7</version>
+    <version>1.1.8</version>
     <packaging>jar</packaging>
 
     <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.0.3.RELEASE</version>
+        <version>2.0.4.RELEASE</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -161,6 +161,7 @@
         <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.reflections</groupId>

--- a/src/main/java/moe/tristan/easyfxml/model/awt/integrations/SystemTrayIcon.java
+++ b/src/main/java/moe/tristan/easyfxml/model/awt/integrations/SystemTrayIcon.java
@@ -6,6 +6,7 @@ import java.awt.event.ActionListener;
 import java.awt.event.MouseListener;
 import java.net.URL;
 import java.util.Map;
+import java.util.Optional;
 
 /**
  * A SystemTrayIcon is a UI object owned by this application that lies in the operating system's (if supported) tray.
@@ -33,11 +34,18 @@ public interface SystemTrayIcon {
     Map<MenuItem, ActionListener> getMenuItems();
 
     /**
+     * Allows setting up an action on mouse click on the tray icon.
+     * Please note that this is only effective on Windows and some Linux tray implementations.
+     * <p>
+     * On macOS and some other Linux tray implementations, this is ineffective as left click will always only open the menu panel.
+     * <p>
+     * On top of that, trying to force its usage on these platforms can lead to UI glitches.
+     *
      * @return The {@link MouseListener} called when a click is detected on the {@link TrayIcon}.
      *
      * @see moe.tristan.easyfxml.model.awt.objects.OnMouseClickListener
      * @see TrayIcon#addMouseListener(java.awt.event.MouseListener)
      */
-    MouseListener onMouseClickListener();
+    Optional<MouseListener> onMouseClickListener();
 
 }

--- a/src/main/java/moe/tristan/easyfxml/model/awt/integrations/SystemTraySupport.java
+++ b/src/main/java/moe/tristan/easyfxml/model/awt/integrations/SystemTraySupport.java
@@ -44,7 +44,7 @@ public class SystemTraySupport {
                            })
                    )).thenApplyAsync(trayIconRes -> trayIconRes.map(icon -> {
                     icon.setImageAutoSize(true);
-                    icon.addMouseListener(systemTrayIcon.onMouseClickListener());
+                    systemTrayIcon.onMouseClickListener().ifPresent(icon::addMouseListener);
                     return icon;
                 }));
     }

--- a/src/main/java/moe/tristan/easyfxml/model/awt/integrations/SystemTraySupport.java
+++ b/src/main/java/moe/tristan/easyfxml/model/awt/integrations/SystemTraySupport.java
@@ -19,7 +19,10 @@ import java.util.stream.Collectors;
 
 /**
  * Allows creation/management of a custom system tray icon.
+ *
+ * @deprecated Check out Dorkbox's SystemTray library for that matter. It is much more resilient.
  */
+@Deprecated
 @Component
 public class SystemTraySupport {
 

--- a/src/main/java/moe/tristan/easyfxml/model/system/BrowserSupport.java
+++ b/src/main/java/moe/tristan/easyfxml/model/system/BrowserSupport.java
@@ -1,14 +1,15 @@
-package moe.tristan.easyfxml.model.awt.integrations;
+package moe.tristan.easyfxml.model.system;
 
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import moe.tristan.easyfxml.model.exception.ExceptionHandler;
 import io.vavr.control.Try;
 
-import java.awt.Desktop;
 import java.net.URI;
 import java.net.URL;
-import java.util.Objects;
 import java.util.function.Consumer;
+
+import javafx.application.HostServices;
 
 /**
  * This class contains some utility methods to open URLs with the default web browser of the user.
@@ -16,20 +17,25 @@ import java.util.function.Consumer;
 @Component
 public class BrowserSupport {
 
+    private final HostServices hostServices;
+
+    @Autowired
+    public BrowserSupport(HostServices hostServices) {
+        this.hostServices = hostServices;
+    }
+
     /**
      * Opens a given URL or a pop-up with the error if it could not do so.
      *
-     * @param url The URL as a String. Must conform to {@link URL#URL(String)}.
+     * @param url The URL as a String. Does not have to conform to {@link URL#URL(String)}.
      *
      * @return a {@link Try} that can be either {@link Try.Success} (and empty) or {@link Try.Failure} and contain an
      * exception.
      * @see Try#onFailure(Consumer)
      */
     public Try<Void> openUrl(final String url) {
-        return Try.of(() -> url)
-                  .mapTry(URL::new)
-                  .flatMap(this::openUrl)
-                  .onFailure(cause -> this.onException(cause, url));
+        return Try.run(() -> hostServices.showDocument(url))
+                  .onFailure(cause -> onException(cause, url));
     }
 
     /**
@@ -44,13 +50,8 @@ public class BrowserSupport {
     public Try<Void> openUrl(final URL url) {
         return Try.of(() -> url)
                   .mapTry(URL::toURI)
-                  .flatMap(this::browse)
-                  .onFailure(cause -> this.onException(cause, Objects.toString(url)));
-    }
-
-    private Try<Void> browse(final URI uri) {
-        return Try.run(() -> Desktop.getDesktop().browse(uri))
-                  .onFailure(cause -> onException(cause, uri.toString()));
+                  .map(URI::toString)
+                  .flatMap(this::openUrl);
     }
 
     private void onException(final Throwable cause, final String url) {

--- a/src/main/java/moe/tristan/easyfxml/spring/application/NativeJFXComponents.java
+++ b/src/main/java/moe/tristan/easyfxml/spring/application/NativeJFXComponents.java
@@ -1,0 +1,17 @@
+package moe.tristan.easyfxml.spring.application;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import javafx.application.Application;
+import javafx.application.HostServices;
+
+@Configuration
+public class NativeJFXComponents {
+
+    @Bean
+    public HostServices hostServices(final Application application) {
+        return application.getHostServices();
+    }
+
+}

--- a/src/test/java/moe/tristan/easyfxml/model/awt/integrations/BrowserSupportTest.java
+++ b/src/test/java/moe/tristan/easyfxml/model/awt/integrations/BrowserSupportTest.java
@@ -11,11 +11,9 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.testfx.framework.junit.ApplicationTest;
 
-import java.net.MalformedURLException;
 import java.net.URL;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @ContextConfiguration(classes = FxSpringContext.class)
 @RunWith(SpringJUnit4ClassRunner.class)

--- a/src/test/java/moe/tristan/easyfxml/model/awt/integrations/BrowserSupportTest.java
+++ b/src/test/java/moe/tristan/easyfxml/model/awt/integrations/BrowserSupportTest.java
@@ -3,6 +3,8 @@ package moe.tristan.easyfxml.model.awt.integrations;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+import moe.tristan.easyfxml.model.system.BrowserSupport;
 import moe.tristan.easyfxml.spring.application.FxSpringContext;
 import io.vavr.control.Try;
 import org.junit.Test;
@@ -13,6 +15,7 @@ import java.net.MalformedURLException;
 import java.net.URL;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @ContextConfiguration(classes = FxSpringContext.class)
 @RunWith(SpringJUnit4ClassRunner.class)
@@ -30,8 +33,8 @@ public class BrowserSupportTest extends ApplicationTest {
     public void openUrl_bad_url() {
         Try<Void> invalidUrlOpening = browserSupport.openUrl("not_a_url");
 
-        assertThat(invalidUrlOpening.isFailure()).isTrue();
-        assertThat(invalidUrlOpening.getCause()).isInstanceOf(MalformedURLException.class);
+        // JFX url opening works for anything, it will just basically try to open it in browser and that's it
+        assertThat(invalidUrlOpening.isFailure()).isFalse();
     }
 
     @Test

--- a/src/test/java/moe/tristan/easyfxml/model/awt/integrations/SystemTraySupportTest.java
+++ b/src/test/java/moe/tristan/easyfxml/model/awt/integrations/SystemTraySupportTest.java
@@ -20,6 +20,7 @@ import java.awt.event.MouseListener;
 import java.net.URL;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeoutException;
@@ -101,8 +102,8 @@ public class SystemTraySupportTest {
             }
 
             @Override
-            public MouseListener onMouseClickListener() {
-                return onMouseClickListener;
+            public Optional<MouseListener> onMouseClickListener() {
+                return Optional.of(onMouseClickListener);
             }
         };
     }

--- a/src/test/java/moe/tristan/easyfxml/model/awt/integrations/SystemTraySupportTest.java
+++ b/src/test/java/moe/tristan/easyfxml/model/awt/integrations/SystemTraySupportTest.java
@@ -30,6 +30,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 /**
  * This test is wholly incomplete. Consider it absent for now.
  */
+@SuppressWarnings("deprecation")
 @ContextConfiguration(classes = FxSpringContext.class)
 @RunWith(SpringRunner.class)
 public class SystemTraySupportTest {
@@ -37,7 +38,7 @@ public class SystemTraySupportTest {
     private static final String TRAY_LABEL = "TEST_LABEL";
     private static final URL TRAY_ICON_URL = getTrayIcon();
 
-    private BooleanProperty clickRegistered = new SimpleBooleanProperty(false);
+    private final BooleanProperty clickRegistered = new SimpleBooleanProperty(false);
 
     @Autowired
     private ApplicationContext applicationContext;

--- a/src/test/java/moe/tristan/easyfxml/model/components/listview/ComponentListViewFxmlControllerTest.java
+++ b/src/test/java/moe/tristan/easyfxml/model/components/listview/ComponentListViewFxmlControllerTest.java
@@ -69,12 +69,14 @@ public class ComponentListViewFxmlControllerTest extends ApplicationTest {
         assertThat(testButton).isInstanceOf(Button.class);
         assertThat(testButton.getText()).isEqualTo(TEST_BUTTON_SUCCESS_TEXT);
 
-        assertThat(clvsfc.scrolledToEnd.get()).isFalse();
-        clvsfc.listView.scrollTo(1);
-        assertThat(clvsfc.scrolledToEnd.get()).isFalse();
-        clvsfc.listView.scrollTo(99);
+        Platform.runLater(() -> {
+            assertThat(clvsfc.scrolledToEnd.get()).isFalse();
+            clvsfc.listView.scrollTo(1);
+            assertThat(clvsfc.scrolledToEnd.get()).isFalse();
+            clvsfc.listView.scrollTo(99);
 
-        await().atMost(1, TimeUnit.SECONDS).until(() -> clvsfc.scrolledToEnd.get());
+            await().atMost(1, TimeUnit.SECONDS).until(() -> clvsfc.scrolledToEnd.get());
+        });
     }
 
     private ComponentListViewSampleFxmlController setUpStage() throws InterruptedException, ExecutionException, TimeoutException {

--- a/src/test/java/moe/tristan/easyfxml/model/system/BrowserSupportTest.java
+++ b/src/test/java/moe/tristan/easyfxml/model/system/BrowserSupportTest.java
@@ -1,4 +1,4 @@
-package moe.tristan.easyfxml.model.awt.integrations;
+package moe.tristan.easyfxml.model.system;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ContextConfiguration;


### PR DESCRIPTION
- Deprecate SystemTraySupport in favor of using https://git.dorkbox.com/dorkbox/SystemTray .
- Change BrowserSupport back-end from AWT-based to JavaFX-based. No API change except package name. Just reimport it and all is good.
- Bump Spring Boot version
- Make mouse click listener for tray icons an Optional in TrayIcon due to inconsistent behavior across multiple systems (notable some Linux distributions as well as macOS not reacting to left-click correctly)
- Make assertj test-scoped to pollute classpath a little less