### PR TITLE
Move to reverse-dns module names

### DIFF
--- a/easyfxml-junit/src/main/java/module-info.java
+++ b/easyfxml-junit/src/main/java/module-info.java
@@ -1,4 +1,5 @@
-open module easyfxml.junit {
+open module moe.tristan.easyfxml.junit {
+
     exports moe.tristan.easyfxml.test;
 
     requires transitive javafx.graphics;

--- a/easyfxml-junit/src/main/java/module-info.java
+++ b/easyfxml-junit/src/main/java/module-info.java
@@ -1,6 +1,6 @@
 open module moe.tristan.easyfxml.junit {
 
-    exports moe.tristan.easyfxml.test;
+    exports moe.tristan.easyfxml.junit;
 
     requires transitive javafx.graphics;
 

--- a/easyfxml-junit/src/main/java/moe/tristan/easyfxml/junit/FxNodeTest.java
+++ b/easyfxml-junit/src/main/java/moe/tristan/easyfxml/junit/FxNodeTest.java
@@ -1,4 +1,4 @@
-package moe.tristan.easyfxml.test;
+package moe.tristan.easyfxml.junit;
 
 import static java.util.Collections.emptyList;
 import static org.awaitility.Awaitility.await;

--- a/easyfxml-samples/easyfxml-sample-hello-world/src/main/java/module-info.java
+++ b/easyfxml-samples/easyfxml-sample-hello-world/src/main/java/module-info.java
@@ -1,9 +1,9 @@
 /**
  * EasyFXML has full support for the module path!
  */
-open module easyfxml.sample.helloworld {
+open module moe.tristan.easyfxml.samples.helloworld {
 
-    requires easyfxml;
+    requires moe.tristan.easyfxml;
 
     requires spring.boot.autoconfigure;
     requires spring.context;

--- a/easyfxml-samples/easyfxml-sample-hello-world/src/test/java/moe/tristan/easyfxml/samples/helloworld/view/hello/HelloComponentTest.java
+++ b/easyfxml-samples/easyfxml-sample-hello-world/src/test/java/moe/tristan/easyfxml/samples/helloworld/view/hello/HelloComponentTest.java
@@ -15,7 +15,7 @@ import javafx.scene.layout.Pane;
 
 import moe.tristan.easyfxml.EasyFxml;
 import moe.tristan.easyfxml.model.exception.ExceptionHandler;
-import moe.tristan.easyfxml.test.FxNodeTest;
+import moe.tristan.easyfxml.junit.FxNodeTest;
 
 @SpringBootTest
 @RunWith(SpringRunner.class)

--- a/easyfxml/src/main/java/module-info.java
+++ b/easyfxml/src/main/java/module-info.java
@@ -1,4 +1,4 @@
-open module easyfxml {
+open module moe.tristan.easyfxml {
     exports moe.tristan.easyfxml;
     exports moe.tristan.easyfxml.api;
     exports moe.tristan.easyfxml.util;

--- a/easyfxml/src/test/java/moe/tristan/easyfxml/util/ButtonsTest.java
+++ b/easyfxml/src/test/java/moe/tristan/easyfxml/util/ButtonsTest.java
@@ -10,7 +10,7 @@ import org.junit.Test;
 import javafx.scene.control.Button;
 import javafx.scene.control.Label;
 
-import moe.tristan.easyfxml.test.FxNodeTest;
+import moe.tristan.easyfxml.junit.FxNodeTest;
 
 public class ButtonsTest extends FxNodeTest {
 

--- a/easyfxml/src/test/java/moe/tristan/easyfxml/util/ClickableTextTest.java
+++ b/easyfxml/src/test/java/moe/tristan/easyfxml/util/ClickableTextTest.java
@@ -7,7 +7,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.junit.Test;
 
-import moe.tristan.easyfxml.test.FxNodeTest;
+import moe.tristan.easyfxml.junit.FxNodeTest;
 
 public class ClickableTextTest extends FxNodeTest {
 


### PR DESCRIPTION
As the Java world moves to a module landscape, it is important to avoid name clashing by following, when possible, a reverse-DNS naming scheme.

Reasons are the same as package naming.